### PR TITLE
解决JDK11以上 插件加载失败问题

### DIFF
--- a/latke-core/src/main/java/org/b3log/latke/plugin/PluginManager.java
+++ b/latke-core/src/main/java/org/b3log/latke/plugin/PluginManager.java
@@ -181,8 +181,15 @@ public class PluginManager {
             LOGGER.log(Level.ERROR, "Reads [" + props.getProperty("classesDirPath") + "] failed", e);
         }
 
-        final URLClassLoader classLoader = new URLClassLoader(new URL[]{
+        URLClassLoader classLoader=null;
+        if(defaultClassesFileDirURL==null){
+            classLoader = new URLClassLoader(new URL[]{
+                classesFileDirURL}, PluginManager.class.getClassLoader());
+        }
+        else{
+            classLoader = new URLClassLoader(new URL[]{
                 defaultClassesFileDirURL, classesFileDirURL}, PluginManager.class.getClassLoader());
+        }
 
         classLoaders.add(classLoader);
 


### PR DESCRIPTION
问题出在 `latke-core 的 org.b3log.latke.plugin.PluginManager` 上，问题代码如下：
```
final URLClassLoader classLoader = new URLClassLoader(new URL[]{
                defaultClassesFileDirURL, classesFileDirURL}, PluginManager.class.getClassLoader());	
```
首先defaultClassesFileDirURL这个变量一般情况下值为null, 在`defaultClassesFileDirURL==null` 的情况下，
- 在 java1.8 版本情况下运行不会抛出异常；
- 在 java11 以后版本情况下运行会抛出异常；
在抛出异常后插件加载失败。把上面代码改成如下形式，问题即可解决：
```
	URLClassLoader classLoader=null;

        if(defaultClassesFileDirURL==null){
            classLoader = new URLClassLoader(new URL[]{
                classesFileDirURL}, PluginManager.class.getClassLoader());
        }
        else{
            classLoader = new URLClassLoader(new URL[]{
                defaultClassesFileDirURL, classesFileDirURL}, PluginManager.class.getClassLoader());
        }
```